### PR TITLE
Fix TimerTaskRunnerElement definition

### DIFF
--- a/src/Core/Configuration/TimerTaskRunnerElement.cs
+++ b/src/Core/Configuration/TimerTaskRunnerElement.cs
@@ -70,7 +70,7 @@ namespace XecMe.Core.Configuration
         /// Gets or sets the reccurrence of the instance. Default value is -1 that indicates there is no upper bound defined for this task
         /// </summary>
         [ConfigurationProperty(RECURRENCE, IsRequired = false, DefaultValue = -1L)]
-        [LongValidator(MinValue = 0L, MaxValue = long.MaxValue)]
+        [LongValidator(MinValue = -1L, MaxValue = long.MaxValue)]
         public long Recurrence
         {
             get { return (long)base[RECURRENCE]; }


### PR DESCRIPTION
Because of modification https://github.com/slolam/XecMe/commit/9f385f51eed925b9578a2e25bd680f43c24b955e#diff-fad8054c0c7e7294b220b7a52d34c79eR91 `TimerTaskRunner` is no more usable through config file. 

Indeed `DefaultValue` is set to an invalid value regarding the property validator.

Thanks to this commit, everything comes back to normal.

Thanks for this awesome lib'
